### PR TITLE
setting value of auto complete

### DIFF
--- a/src/FormsyAutoComplete.jsx
+++ b/src/FormsyAutoComplete.jsx
@@ -39,14 +39,14 @@ const FormsyAutoComplete = createClass({
   },
 
   handleChange: function handleChange(event) {
-    this.setState({
+    this.setValue({
       value: event.currentTarget.value,
     });
     if (this.props.onChange) this.props.onChange(event);
   },
 
   handleUpdateInput: function handleUpdateInput(value) {
-    this.setState({
+    this.setValue({
       value,
     });
     if (this.props.onChange) this.props.onChange(null, value);


### PR DESCRIPTION
Addresses two problems:
- If using FormsyAutoComplete a user begins to type and uses the keyboard to select the first option in the AutoComplete menus (Keyboard, not mouse click) `handleBlur` will set `_value` before the selected autocomplete item text is set in the input.
- If, for some reason, `blur` is not triggered on the AutoComplete element, an incorrect value can be set for the formsy element/model.

Since there is little value of having a state attribute of `value` lets use the helper function (through the mixin) to guarantee that formsy has the most "up-to-date" value.